### PR TITLE
Add default config nodes for import node by adding addDefaultsIfNotSet

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,12 +26,14 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('import')
+                    ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('use_legacy_id')->defaultFalse()->end()
                         ->scalarNode('batch_size')->defaultValue('15')->end()
                         ->scalarNode('use_owner')->defaultFalse()->end()
                     ->end()
-             ->end();
+                ->end()
+            ->end();
 
 
         return $treeBuilder;


### PR DESCRIPTION
Problem:

Using this bundle as plug-and-play without any custom configuration didn't work and I got the following exception:

```
[ErrorException]
  Notice: Undefined index: import in /...project.../vendor/avro/csv-bundle/Avro/CsvBundle/DependencyInjection/AvroCsvExtension.php line 27
```

Solution:

I added the addDefaultsIfNotSet method to the import array node so that the defined children are handled as defaults when no children are defined within the application.
