### PR TITLE
Update Resources/config/config.yml

### DIFF
--- a/Resources/config/config.yml
+++ b/Resources/config/config.yml
@@ -11,7 +11,7 @@ services:
         factory_method: createNamed 
         factory_service: form.factory
         class: Symfony\Component\Form\Form
-        arguments: ["@avro_csv.form.type", avro_csv_csv]
+        arguments: [avro_csv_csv, "@avro_csv.form.type"]
 
     avro_csv.form.handler:
         class: Avro\CsvBundle\Form\Handler\CsvFormHandler


### PR DESCRIPTION
Reversing the order of arguments to form factory method to fix a type casting issue in the process of constructing the form builder for CsvFormType.  Per use of the arguments in FormFactory::createNamed and subsequent calls, I think this is the solution.  This seems to solve the problem in https://github.com/jdewit/AvroCsvBundle/issues/5
