### PR TITLE
documentation update: avro/case-bundle should be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ This bundle is listed on packagist.
 Simply add it to your apps composer.json file
 
 ``` js
-    "avro/csv-bundle": "*"
+    "avro/csv-bundle": "*",
+    "avro/case-bundle": "*"
 ```
 
 Enable the bundle in the kernel as well as the dependent AvroCaseBundle:


### PR DESCRIPTION
In documentaion it isn't mentioned that `avro/case-buncle` should also be installed.
