### PR TITLE
Fix type hints, Symfony code style and 3.0 compatibilty

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,10 @@
+<?php
+return PhpCsFixer\Config::create()
+    ->setRules(
+        array(
+            '@Symfony' => true,
+            'ordered_imports' => true,
+        )
+    )
+    ->setUsingCache(true)
+    ->setCacheFile(__DIR__.'/.php_cs.cache');

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
 language: php
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
 
-before_script: 
-  - curl --silent http://getcomposer.org/installer | php
-  - php composer.phar install --dev --no-interaction --prefer-dist
+before_install:
+  - |
+    # php.ini configuration
+    INI=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    phpenv config-rm xdebug.ini || echo "xdebug not available"
+    echo memory_limit = -1 >> $INI
+
+install:
+  - composer install --no-interaction --prefer-dist
 
 notifications:
   email: joris.w.dewit@gmail.com

--- a/Annotation/ImportExclude.php
+++ b/Annotation/ImportExclude.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Avro\CsvBundle\Annotation;
 
 /**

--- a/Controller/ExportController.php
+++ b/Controller/ExportController.php
@@ -7,15 +7,10 @@
 
 namespace Avro\CsvBundle\Controller;
 
-use Doctrine\Orm\Query;
-
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\DependencyInjection\ContainerAware;
-
-use Avro\CsvBundle\Event\ExportEvent;
 use Avro\CsvBundle\Event\ExportedEvent;
+use Avro\CsvBundle\Event\ExportEvent;
+use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * CSV Export controller.
@@ -29,7 +24,7 @@ class ExportController extends ContainerAware
      *
      * @param string $alias The objects alias
      *
-     * @return View
+     * @return Response
      */
     public function exportAction($alias)
     {
@@ -52,4 +47,3 @@ class ExportController extends ContainerAware
         return $response;
     }
 }
-

--- a/DependencyInjection/AvroCsvExtension.php
+++ b/DependencyInjection/AvroCsvExtension.php
@@ -1,22 +1,27 @@
 <?php
-namespace Avro\CsvBundle\DependencyInjection;
-
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\Config\FileLocator;
-use Symfony\Component\Config\Definition\Processor;
-use Symfony\Component\DependencyInjection\Alias;
 
 /**
- * Bundle DIC Extension
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Avro\CsvBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+/**
+ * Bundle DIC Extension.
  *
  * @author Joris de Wit <joris.w.dewit@gmail.com>
  */
 class AvroCsvExtension extends Extension
 {
     /**
-     * Load bundle config
+     * Load bundle config.
      *
      * @param array            $configs   Config array
      * @param ContainerBuilder $container The container builder

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,16 +1,20 @@
 <?php
 
+/**
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Avro\CsvBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
-* Contains the configuration information for the bundle
-*
-* @author Joris de Wit <joris.w.dewit@gmail.com>
-*/
+ * Contains the configuration information for the bundle.
+ *
+ * @author Joris de Wit <joris.w.dewit@gmail.com>
+ */
 class Configuration implements ConfigurationInterface
 {
     /**
@@ -43,5 +47,4 @@ class Configuration implements ConfigurationInterface
 
         return $treeBuilder;
     }
-
 }

--- a/Doctrine/Importer.php
+++ b/Doctrine/Importer.php
@@ -7,37 +7,63 @@
 
 namespace Avro\CsvBundle\Doctrine;
 
-
 use Avro\CaseBundle\Util\CaseConverter;
-use Avro\CsvBundle\Annotation\Exclude;
 use Avro\CsvBundle\Event\RowAddedEvent;
 use Avro\CsvBundle\Util\Reader;
-
 use Doctrine\Common\Persistence\ObjectManager;
-
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
- * Import csv to doctrine entity/document
+ * Import csv to doctrine entity/document.
  *
  * @author Joris de Wit <joris.w.dewit@gmail.com>
  */
 class Importer
 {
+    /**
+     * @var string[]
+     */
+    protected $headers;
+    /**
+     * @var string[]
+     */
     protected $fields;
+    /**
+     * @var ClassMetadataInfo
+     */
     protected $metadata;
+    /**
+     * @var Reader
+     */
     protected $reader;
+    /**
+     * @var int
+     */
     protected $batchSize;
+    /**
+     * @var int
+     */
     protected $importCount = 0;
+    /**
+     * @var CaseConverter
+     */
     protected $caseConverter;
+    /**
+     * @var ObjectManager
+     */
     protected $objectManager;
+    /**
+     * @var string
+     */
+    protected $class;
 
     /**
-     * @param CsvReader     $reader        The csv reader
-     * @param Dispatcher    $dispatcher    The event dispatcher
-     * @param CaseConverter $caseConverter The case Converter
-     * @param ObjectManager $objectManager The Doctrine Object Manager
-     * @param int           $batchSize     The batch size before flushing & clearing the om
+     * @param Reader                   $reader        The csv reader
+     * @param EventDispatcherInterface $dispatcher    The event dispatcher
+     * @param CaseConverter            $caseConverter The case Converter
+     * @param ObjectManager            $objectManager The Doctrine Object Manager
+     * @param int                      $batchSize     The batch size before flushing & clearing the om
      */
     public function __construct(Reader $reader, EventDispatcherInterface $dispatcher, CaseConverter $caseConverter, ObjectManager $objectManager, $batchSize)
     {
@@ -49,14 +75,14 @@ class Importer
     }
 
     /**
-     * Import a file
+     * Import a file.
      *
-     * @param File   $file         The csv file
+     * @param string $file         The csv file
      * @param string $class        The class name of the entity
      * @param string $delimiter    The csv's delimiter
      * @param string $headerFormat The header case format
      *
-     * @return boolean true if successful
+     * @return bool true if successful
      */
     public function init($file, $class, $delimiter = ',', $headerFormat = 'title')
     {
@@ -67,7 +93,7 @@ class Importer
     }
 
     /**
-     * Get the csv's header row
+     * Get the csv's header row.
      *
      * @return array
      */
@@ -77,7 +103,7 @@ class Importer
     }
 
     /**
-     * Get the csv's next row
+     * Get the csv's next row.
      *
      * @return array
      */
@@ -87,7 +113,7 @@ class Importer
     }
 
     /**
-     * Import the csv and persist to database
+     * Import the csv and persist to database.
      *
      * @param array $fields The fields to persist
      *
@@ -103,7 +129,7 @@ class Importer
             } else {
                 $this->addRow($row, $fields, false);
             }
-            $this->importCount++;
+            ++$this->importCount;
         }
 
         // one last flush to make sure no persisted objects get left behind
@@ -113,11 +139,11 @@ class Importer
     }
 
     /**
-     * Add Csv row to db
+     * Add Csv row to db.
      *
-     * @param array   $row      An array of data
-     * @param array   $fields   An array of the fields to import
-     * @param boolean $andFlush Flush the ObjectManager
+     * @param array $row      An array of data
+     * @param array $fields   An array of the fields to import
+     * @param bool  $andFlush Flush the ObjectManager
      */
     private function addRow($row, $fields, $andFlush = true)
     {
@@ -136,8 +162,8 @@ class Importer
         foreach ($fields as $k => $v) {
             if ($this->metadata->hasField(lcfirst($v))) {
                 $entity->{'set'.$fields[$k]}($row[$k]);
-            } else if ($this->metadata->hasAssociation(lcfirst($v))) {
-                $association = $this->metadata->associationMappings[lcfirst($v)];
+            } elseif ($this->metadata->hasAssociation(lcfirst($v))) {
+                $association = $this->metadata->getAssociationMapping(lcfirst($v));
                 switch ($association['type']) {
                     case '1': // oneToOne
                         //Todo:
@@ -161,7 +187,7 @@ class Importer
                                         $entity->{'set'.ucfirst($association['fieldName'])}($relation);
                                     }
                                 }
-                            } catch(\Exception $e) {
+                            } catch (\Exception $e) {
                                 // legacyId does not exist
                                 // fail silently
                             }
@@ -188,7 +214,7 @@ class Importer
     }
 
     /**
-     * Get import count
+     * Get import count.
      *
      * @return int
      */

--- a/Event/ExportEvent.php
+++ b/Event/ExportEvent.php
@@ -8,11 +8,11 @@
 namespace Avro\CsvBundle\Event;
 
 use Avro\CsvBundle\Export\ExporterInterface;
-
+use Doctrine\DBAL\Query\QueryBuilder;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Export initialized event
+ * Export initialized event.
  *
  * @author Joris de Wit <joris.w.dewit@gmail.com>
  */
@@ -21,7 +21,7 @@ class ExportEvent extends Event
     protected $exporter;
 
     /**
-     * @param Exporter $exporter The Avro Exporter service
+     * @param ExporterInterface $exporter The Avro Exporter service
      */
     public function __construct(ExporterInterface $exporter)
     {
@@ -29,9 +29,9 @@ class ExportEvent extends Event
     }
 
     /**
-     * Get the avro exporter
+     * Get the avro exporter.
      *
-     * @return AvroExporter
+     * @return ExporterInterface
      */
     public function getExporter()
     {
@@ -39,7 +39,7 @@ class ExportEvent extends Event
     }
 
     /**
-     * Get the queryBuilder
+     * Get the queryBuilder.
      *
      * @return QueryBuilder
      */
@@ -48,4 +48,3 @@ class ExportEvent extends Event
         return $this->exporter->getQueryBuilder();
     }
 }
-

--- a/Event/ExportedEvent.php
+++ b/Event/ExportedEvent.php
@@ -7,45 +7,32 @@
 
 namespace Avro\CsvBundle\Event;
 
-use Avro\CsvBundle\Export\ExporterInterface;
-
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Export initialized event
+ * Export initialized event.
  *
  * @author Joris de Wit <joris.w.dewit@gmail.com>
  */
-class ExportInitializedEvent extends Event
+class ExportedEvent extends Event
 {
-    protected $exporter;
+    protected $content;
 
     /**
-     * @param Exporter $exporter The Avro Exporter service
+     * @param string $content Csv data
      */
-    public function __construct(ExporterInterface $exporter)
+    public function __construct($content)
     {
-        $this->exporter = $exporter;
+        $this->content = $content;
     }
 
     /**
-     * Get the avro exporter
+     * Get the csv data.
      *
-     * @return AvroExporter
+     * @return string
      */
-    public function getExporter()
+    public function getContent()
     {
-        return $this->exporter;
-    }
-
-    /**
-     * Get the queryBuilder
-     *
-     * @return QueryBuilder
-     */
-    public function getQueryBuilder()
-    {
-        return $this->exporter->getQueryBuilder();
+        return $this->content;
     }
 }
-

--- a/Event/RowAddedEvent.php
+++ b/Event/RowAddedEvent.php
@@ -10,7 +10,7 @@ namespace Avro\CsvBundle\Event;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Row added event
+ * Row added event.
  *
  * @author Joris de Wit <joris.w.dewit@gmail.com>
  */
@@ -21,9 +21,9 @@ class RowAddedEvent extends Event
     protected $fields;
 
     /**
-     * @param DoctrineObject $object The new object being persisted
-     * @param array          $row    The row being imported
-     * @param array          $fields The mapped fields
+     * @param \stdClass $object The new object being persisted
+     * @param array     $row    The row being imported
+     * @param array     $fields The mapped fields
      */
     public function __construct($object, array $row, array $fields)
     {
@@ -33,9 +33,9 @@ class RowAddedEvent extends Event
     }
 
     /**
-     * Get the doctrine object
+     * Get the doctrine object.
      *
-     * @return DoctrienObject
+     * @return \stdClass
      */
     public function getObject()
     {
@@ -43,7 +43,7 @@ class RowAddedEvent extends Event
     }
 
     /**
-     * Get field row
+     * Get field row.
      *
      * @return array
      */
@@ -53,7 +53,7 @@ class RowAddedEvent extends Event
     }
 
     /**
-     * Get mapped fields
+     * Get mapped fields.
      *
      * @return array
      */
@@ -62,4 +62,3 @@ class RowAddedEvent extends Event
         return $this->fields;
     }
 }
-

--- a/Export/Doctrine/ORM/Exporter.php
+++ b/Export/Doctrine/ORM/Exporter.php
@@ -7,11 +7,8 @@
 
 namespace Avro\CsvBundle\Export\Doctrine\ORM;
 
-use Avro\CaseBundle\Util\Converter;
-
 use Avro\CsvBundle\Export\Exporter as BaseExporter;
 use Avro\CsvBundle\Export\ExporterInterface;
-
 use Doctrine\ORM\EntityManager;
 
 /**
@@ -24,7 +21,7 @@ class Exporter extends BaseExporter implements ExporterInterface
     protected $entityManager;
 
     /**
-     * @param entityManager $entityManager The csv entityManager
+     * @param EntityManager $entityManager The csv entityManager
      */
     public function __construct(EntityManager $entityManager)
     {

--- a/Export/Exporter.php
+++ b/Export/Exporter.php
@@ -7,31 +7,32 @@
 
 namespace Avro\CsvBundle\Export;
 
-use Doctrine\Orm\Query;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\QueryBuilder;
 
 /**
- * Import csv to doctrine entity/document
+ * Import csv to doctrine entity/document.
  *
  * @author Joris de Wit <joris.w.dewit@gmail.com>
  */
 abstract class Exporter
 {
+    /**
+     * @var QueryBuilder
+     */
     protected $queryBuilder;
 
     /**
-     * Export all of an objects data to csv format
+     * Export all of an objects data to csv format.
      *
-     * @return $content
+     * @return string
      */
     public function getContent()
     {
-        $iteratableResults = $this->queryBuilder->getQuery()->iterate(null, 2);
+        $iterableResults = $this->queryBuilder->getQuery()->iterate(null, 2);
 
         $content = null;
-        foreach ($iteratableResults as $row) {
+        foreach ($iterableResults as $row) {
             $row = reset($row);
-
             if ($content == null) {
                 $content = $this->arrayToCsv(array_keys($row));
             }
@@ -42,26 +43,26 @@ abstract class Exporter
     }
 
     /**
-      * Converts an array into a CSV string.
-      *
-      * @param array  $fields    The php array to convert
-      * @param string $delimiter The CSV delimiter
-      * @param string $enclosure The CSV enclosure
-      *
-      * @return string CSV formatted string
-      */
+     * Converts an array into a CSV string.
+     *
+     * @param array  $fields    The php array to convert
+     * @param string $delimiter The CSV delimiter
+     * @param string $enclosure The CSV enclosure
+     *
+     * @return string CSV formatted string
+     */
     public function arrayToCsv(array $fields, $delimiter = ',', $enclosure = '"')
     {
         $output = array();
         foreach ($fields as $field) {
-            $output[] = $enclosure . str_replace($enclosure, $enclosure . $enclosure, $this->stringify($field)) . $enclosure;
+            $output[] = $enclosure.str_replace($enclosure, $enclosure.$enclosure, $this->stringify($field)).$enclosure;
         }
 
-        return implode($delimiter, $output) . "\n";
+        return implode($delimiter, $output)."\n";
     }
 
     /**
-     * Get the queryBuilder
+     * Get the queryBuilder.
      *
      * @return QueryBuilder $queryBuilder
      */
@@ -70,23 +71,23 @@ abstract class Exporter
         return $this->queryBuilder;
     }
 
-	/**
-	 * Convert the subject to a string.
-	 *
-	 * @param mixed $field
-	 *
-	 * @return string
-	 */
-	protected function stringify($field)
-	{
-		if ($field instanceof \Datetime) { // format datetime fields
-			return date_format($field, 'Y-m-d');
-		} elseif (is_object($field) && method_exists($field, '__toString')) {
-			return (string)$field;
-		} elseif (!is_scalar($field)) { // fallback to JSON data representation
-			return json_encode($field);
-		}
+    /**
+     * Convert the subject to a string.
+     *
+     * @param mixed $field
+     *
+     * @return string
+     */
+    protected function stringify($field)
+    {
+        if ($field instanceof \Datetime) { // format datetime fields
+            return date_format($field, 'Y-m-d');
+        } elseif (is_object($field) && method_exists($field, '__toString')) {
+            return (string) $field;
+        } elseif (!is_scalar($field)) { // fallback to JSON data representation
+            return json_encode($field);
+        }
 
-		return $field;
-	}
+        return $field;
+    }
 }

--- a/Export/ExporterInterface.php
+++ b/Export/ExporterInterface.php
@@ -7,6 +7,8 @@
 
 namespace Avro\CsvBundle\Export;
 
+use Doctrine\ORM\QueryBuilder;
+
 /**
  * Exporter interface
  *
@@ -39,6 +41,10 @@ interface ExporterInterface
       */
     public function arrayToCsv(array $fields, $delimiter = ',', $enclosure = '"');
 
+    /**
+     * @return QueryBuilder
+     */
+    public function getQueryBuilder();
 }
 
 

--- a/Form/Type/ImportFormType.php
+++ b/Form/Type/ImportFormType.php
@@ -1,21 +1,23 @@
 <?php
+
 namespace Avro\CsvBundle\Form\Type;
 
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
- * CSV Import Form Type
+ * CSV Import Form Type.
  *
  * @author Joris de Wit <joris.w.dewit@gmail.com>
  */
 class ImportFormType extends AbstractType
 {
     /**
-     * Build form
+     * Build form.
      *
      * @param FormBuilderInterface $builder
      * @param array                $options
@@ -29,24 +31,24 @@ class ImportFormType extends AbstractType
                     ',' => 'comma',
                     ';' => 'semicolon',
                     '|' => 'pipe',
-                    ':' => 'colon'
-                )
+                    ':' => 'colon',
+                ),
             ))
             ->add('file', 'file', array(
                 'label' => 'File',
                 'required' => true,
             ))
             ->add('filename', 'hidden', array(
-                'required' => false
+                'required' => false,
             ))
             ->add('fields', 'collection', array(
                 'label' => 'Fields',
                 'required' => false,
                 'type' => 'choice',
                 'options' => array(
-                    'choices' => $options['field_choices']
+                    'choices' => $options['field_choices'],
                 ),
-                'allow_add' => true
+                'allow_add' => true,
             ));
 
         $builder->addEventListener(FormEvents::PRE_BIND, function (FormEvent $event) {
@@ -62,19 +64,31 @@ class ImportFormType extends AbstractType
     }
 
     /**
-     * Set default options
+     * Set default options.
      *
-     * @param OptionsResolverInterface $resolver The resolver
+     * @param OptionsResolverInterface $resolver The resolver for the options.
+     *
+     * @deprecated since version 2.7, to be renamed in 3.0.
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
+        $this->configureOptions($resolver);
+    }
+
+    /**
+     * Configures the options for this type.
+     *
+     * @param OptionsResolver $resolver The resolver for the options
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
         $resolver->setDefaults(array(
-            'field_choices' => array()
+            'field_choices' => array(),
         ));
     }
 
     /**
-     * Get the forms name
+     * Get the forms name.
      *
      * @return string name
      */

--- a/Import/Importer.php
+++ b/Import/Importer.php
@@ -8,35 +8,62 @@
 namespace Avro\CsvBundle\Import;
 
 use Avro\CaseBundle\Util\CaseConverter;
-use Avro\CsvBundle\Annotation\Exclude;
 use Avro\CsvBundle\Event\RowAddedEvent;
 use Avro\CsvBundle\Util\Reader;
-
 use Doctrine\Common\Persistence\ObjectManager;
-
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
- * Import csv to doctrine entity/document
+ * Import csv to doctrine entity/document.
  *
  * @author Joris de Wit <joris.w.dewit@gmail.com>
  */
 class Importer
 {
+    /**
+     * @var string[]
+     */
+    protected $headers;
+    /**
+     * @var string[]
+     */
     protected $fields;
+    /**
+     * @var ClassMetadataInfo
+     */
     protected $metadata;
+    /**
+     * @var Reader
+     */
     protected $reader;
+    /**
+     * @var int
+     */
     protected $batchSize = 20;
+    /**
+     * @var int
+     */
     protected $importCount = 0;
+    /**
+     * @var CaseConverter
+     */
     protected $caseConverter;
+    /**
+     * @var ObjectManager
+     */
     protected $objectManager;
+    /**
+     * @var string
+     */
+    protected $class;
 
     /**
-     * @param CsvReader     $reader        The csv reader
-     * @param Dispatcher    $dispatcher    The event dispatcher
-     * @param CaseConverter $caseConverter The case Converter
-     * @param ObjectManager $objectManager The Doctrine Object Manager
-     * @param int           $batchSize     The batch size before flushing & clearing the om
+     * @param Reader                   $reader        The csv reader
+     * @param EventDispatcherInterface $dispatcher    The event dispatcher
+     * @param CaseConverter            $caseConverter The case Converter
+     * @param ObjectManager            $objectManager The Doctrine Object Manager
+     * @param int                      $batchSize     The batch size before flushing & clearing the om
      */
     public function __construct(Reader $reader, EventDispatcherInterface $dispatcher, CaseConverter $caseConverter, ObjectManager $objectManager, $batchSize)
     {
@@ -48,14 +75,14 @@ class Importer
     }
 
     /**
-     * Import a file
+     * Import a file.
      *
-     * @param File   $file         The csv file
+     * @param string $file         The csv file
      * @param string $class        The class name of the entity
      * @param string $delimiter    The csv's delimiter
      * @param string $headerFormat The header case format
      *
-     * @return boolean true if successful
+     * @return bool true if successful
      */
     public function init($file, $class, $delimiter = ',', $headerFormat = 'title')
     {
@@ -66,7 +93,7 @@ class Importer
     }
 
     /**
-     * Import the csv and persist to database
+     * Import the csv and persist to database.
      *
      * @param array $fields The fields to persist
      *
@@ -82,7 +109,7 @@ class Importer
             } else {
                 $this->addRow($row, $fields, false);
             }
-            $this->importCount++;
+            ++$this->importCount;
         }
 
         // one last flush to make sure no persisted objects get left behind
@@ -92,11 +119,11 @@ class Importer
     }
 
     /**
-     * Add Csv row to db
+     * Add Csv row to db.
      *
-     * @param array   $row      An array of data
-     * @param array   $fields   An array of the fields to import
-     * @param boolean $andFlush Flush the ObjectManager
+     * @param array $row      An array of data
+     * @param array $fields   An array of the fields to import
+     * @param bool  $andFlush Flush the ObjectManager
      */
     private function addRow($row, $fields, $andFlush = true)
     {
@@ -115,7 +142,7 @@ class Importer
         foreach ($fields as $k => $v) {
             if ($this->metadata->hasField(lcfirst($v))) {
                 $entity->{'set'.$fields[$k]}($row[$k]);
-            } else if ($this->metadata->hasAssociation(lcfirst($v))) {
+            } elseif ($this->metadata->hasAssociation(lcfirst($v))) {
                 $association = $this->metadata->associationMappings[lcfirst($v)];
                 switch ($association['type']) {
                     case '1': // oneToOne
@@ -140,7 +167,7 @@ class Importer
                                         $entity->{'set'.ucfirst($association['fieldName'])}($relation);
                                     }
                                 }
-                            } catch(\Exception $e) {
+                            } catch (\Exception $e) {
                                 // legacyId does not exist
                                 // fail silently
                             }
@@ -167,7 +194,7 @@ class Importer
     }
 
     /**
-     * Get import count
+     * Get import count.
      *
      * @return int
      */

--- a/Tests/Export/Doctrine/ORM/ExporterTest.php
+++ b/Tests/Export/Doctrine/ORM/ExporterTest.php
@@ -1,24 +1,28 @@
 <?php
 
+/**
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Avro\CsvBundle\Tests\Export\Doctrine\ORM;
 
 use Avro\CsvBundle\Export\Doctrine\ORM\Exporter;
-
 use Doctrine\ORM\QueryBuilder;
 
 /**
- * Test exporter class
+ * Test exporter class.
  */
 class ExporterTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * Setup test class
-     *
-     * @return nothing
+     * @var Exporter
      */
+    protected $exporter;
+
     public function setUp()
     {
-        $query = $this->getMock('Doctrine\ORM\Query', array('iterate', 'HYDRATE_ARRAY'), array(), '', false);
+        $query = $this->getMock('Doctrine\ORM\AbstractQuery', array('iterate', 'HYDRATE_ARRAY', 'getSQL', '_doExecute'), array(), '', false);
         $query->expects($this->any())
             ->method('iterate')
             ->will($this->returnValue(array(0 => array(0 => array('row 1' => 'val\'1', 'row 2' => 'val,2', 'row 3' => 'val"3')))));
@@ -47,7 +51,7 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test init
+     * Test init.
      */
     public function testInit()
     {
@@ -56,18 +60,18 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test convert row
+     * Test convert row.
      */
     public function testArrayToCsv()
     {
         $this->assertEquals(
-            '"val\'1","val,2","val""3"' . "\n",
+            '"val\'1","val,2","val""3"'."\n",
             $this->exporter->arrayToCsv(array('val\'1', 'val,2', 'val"3'))
         );
     }
 
     /**
-     * Test convert row
+     * Test convert row.
      */
     public function testGetContent()
     {
@@ -82,5 +86,4 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
             $this->exporter->getContent()
         );
     }
-
 }

--- a/Tests/Import/ImporterTest.php
+++ b/Tests/Import/ImporterTest.php
@@ -1,26 +1,32 @@
 <?php
 
+/**
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Avro\CsvBundle\Tests\Import;
 
 use Avro\CaseBundle\Util\CaseConverter;
 use Avro\CsvBundle\Import\Importer;
 use Avro\CsvBundle\Util\Reader;
 
-use Doctrine\Common\Annotations\AnnotationReader;
-
 /**
- * Test importer class
+ * Test importer class.
  */
 class ImporterTest extends \PHPUnit_Framework_TestCase
 {
-    protected $fieldRetriever;
-    protected $class;
+    /**
+     * @var string[]
+     */
     protected $fields;
+    /**
+     * @var Importer
+     */
+    protected $importer;
 
     /**
-     * Setup test class
-     *
-     * @return nothing
+     * Setup test class.
      */
     public function setUp()
     {
@@ -34,7 +40,7 @@ class ImporterTest extends \PHPUnit_Framework_TestCase
         $metadata = $this->getMockForAbstractClass('Doctrine\Common\Persistence\Mapping\ClassMetadata', array('hasField'));
         $metadata->expects($this->any())
             ->method('hasField')
-            ->will($this->returnCallback(function($value) use ($fields){
+            ->will($this->returnCallback(function ($value) use ($fields) {
                 return in_array($value, $fields);
             }));
 
@@ -50,11 +56,11 @@ class ImporterTest extends \PHPUnit_Framework_TestCase
 
         $this->importer = new Importer($reader, $dispatcher, $caseConverter, $objectManager, 5);
 
-        $this->importer->init(__DIR__ . '/../import.csv', 'Avro\CsvBundle\Tests\TestEntity', ',', 'title');
+        $this->importer->init(__DIR__.'/../import.csv', 'Avro\CsvBundle\Tests\TestEntity', ',', 'title');
     }
 
     /**
-     * Test import
+     * Test import.
      */
     public function testImport()
     {

--- a/Tests/Util/FieldRetrieverTest.php
+++ b/Tests/Util/FieldRetrieverTest.php
@@ -1,15 +1,25 @@
 <?php
 
+/**
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Avro\CsvBundle\Tests\Util;
 
-use Avro\CsvBundle\Util\FieldRetriever;
 use Avro\CaseBundle\Util\CaseConverter;
-
+use Avro\CsvBundle\Util\FieldRetriever;
 use Doctrine\Common\Annotations\AnnotationReader;
 
 class FieldRetrieverTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var FieldRetriever
+     */
     protected $fieldRetriever;
+    /**
+     * @var string
+     */
     protected $class;
 
     public function setUp()
@@ -55,5 +65,4 @@ class FieldRetrieverTest extends \PHPUnit_Framework_TestCase
             )
         );
     }
-
 }

--- a/Tests/Util/ReaderTest.php
+++ b/Tests/Util/ReaderTest.php
@@ -1,11 +1,19 @@
 <?php
 
+/**
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Avro\CsvBundle\Tests\Util;
 
 use Avro\CsvBundle\Util\Reader;
 
 class ReaderTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Reader
+     */
     protected $reader;
 
     public function setUp()

--- a/Util/FieldRetriever.php
+++ b/Util/FieldRetriever.php
@@ -1,15 +1,19 @@
 <?php
 
+/**
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Avro\CsvBundle\Util;
 
-use Doctrine\Common\Annotations\AnnotationReader;
-
-use Avro\CsvBundle\Annotation\ImportExclude;
 use Avro\CaseBundle\Util\CaseConverter;
+use Avro\CsvBundle\Annotation\ImportExclude;
+use Doctrine\Common\Annotations\AnnotationReader;
 
 /**
  * Retrieves the fields of a Doctrine entity/document that
- * are allowed to be imported
+ * are allowed to be imported.
  *
  * @author Joris de Wit <joris.w.dewit@gmail.com>
  */
@@ -29,11 +33,11 @@ class FieldRetriever
     }
 
     /**
-     * Get the entity/documents field names
+     * Get the entity/documents field names.
      *
-     * @param string  $class     The class name
-     * @param string  $format    The desired field case format
-     * @param boolean $copyToKey Copy the field values to their respective key
+     * @param string $class     The class name
+     * @param string $format    The desired field case format
+     * @param bool   $copyToKey Copy the field values to their respective key
      *
      * @return array $fields
      */

--- a/Util/Reader.php
+++ b/Util/Reader.php
@@ -1,10 +1,14 @@
 <?php
-namespace Avro\CsvBundle\Util;
-
-use Avro\CaseBundle\Util\CaseConverter;
 
 /**
- * Read a CSV file
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Avro\CsvBundle\Util;
+
+/**
+ * Read a CSV file.
  *
  * @author Joris de Wit <joris.w.dewit@gmail.com>
  */
@@ -17,13 +21,13 @@ class Reader
     protected $headers;
 
     /**
-     * Open a CSV file
+     * Open a CSV file.
      *
-     * @param string  $file       The file path
-     * @param string  $delimiter  The CSV's delimiter
-     * @param string  $mode       fopen mode
-     * @param string  $enclosure  The enclosure
-     * @param boolean $hasHeaders Does the CSV have any headers?
+     * @param string $file       The file path
+     * @param string $delimiter  The CSV's delimiter
+     * @param string $mode       fopen mode
+     * @param string $enclosure  The enclosure
+     * @param bool   $hasHeaders Does the CSV have any headers?
      */
     public function open($file, $delimiter = ',', $mode = 'r+', $enclosure = '"', $hasHeaders = true)
     {
@@ -38,14 +42,14 @@ class Reader
     }
 
     /**
-     * Return a row
+     * Return a row.
      *
      * @return array or false
      */
     public function getRow()
     {
         if (($row = fgetcsv($this->handle, 1000, $this->delimiter, $this->enclosure)) !== false) {
-            $this->line++;
+            ++$this->line;
 
             return $row;
         } else {
@@ -54,7 +58,7 @@ class Reader
     }
 
     /**
-     * Get an array of rows
+     * Get an array of rows.
      *
      * @param int $count The number of rows to return
      *
@@ -63,7 +67,7 @@ class Reader
     public function getRows($count)
     {
         $rows = array();
-        for ($i=0; $i < $count; $i++) {
+        for ($i = 0; $i < $count; ++$i) {
             $row = $this->getRow();
             if ($row) {
                 $rows[] = $row;
@@ -74,7 +78,7 @@ class Reader
     }
 
     /**
-     * Return entire table
+     * Return entire table.
      *
      * @return array $data
      */
@@ -89,7 +93,7 @@ class Reader
     }
 
     /**
-     * Get headers
+     * Get headers.
      *
      * @return array
      */
@@ -99,7 +103,7 @@ class Reader
     }
 
     /**
-     * Close file
+     * Close file.
      */
     public function __destruct()
     {
@@ -107,5 +111,4 @@ class Reader
             fclose($this->handle);
         }
     }
-
 }

--- a/Util/Writer.php
+++ b/Util/Writer.php
@@ -1,22 +1,38 @@
 <?php
 
+/**
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Avro\CsvBundle\Util;
 
-/*
- * Creates a CSV file from an array
+/**
+ * Creates a CSV file from an array.
  *
  * @author Joris de Wit <joris.w.dewit@gmail.com>
  */
 class Writer
 {
+    /**
+     * @var resource
+     */
     protected $handle;
+    /**
+     * @var string
+     */
     protected $delimiter;
+    /**
+     * @var string
+     */
     protected $enclosure;
+    /**
+     * @var int
+     */
     protected $line;
-    protected $headers;
 
     /**
-     * Open CSV file
+     * Open CSV file.
      *
      * @param $file
      * @param $mode
@@ -33,16 +49,16 @@ class Writer
     }
 
     /**
-     * Convert array to CSV row
+     * Convert array to CSV row.
      *
-     * @param array   $row      The data to convert
-     * @param boolean $addBreak Adds linebreak if true
+     * @param array $row      The data to convert
+     * @param bool  $addBreak Adds linebreak if true
      *
      * @return array
      */
     public function convertRow(array $row, $addBreak = true)
     {
-        $formatValue = function($value) {
+        $formatValue = function ($value) {
             if ($value instanceof \Datetime) {
                 $value = date_format($value, 'Y-m-d');
             }
@@ -53,7 +69,7 @@ class Writer
         $row = implode(array_map($formatValue, $row), ',');
 
         if ($addBreak) {
-          $row = <<<EOT
+            $row = <<<EOT
 
 $row
 
@@ -64,7 +80,7 @@ EOT;
     }
 
     /**
-     * Write a row in the CSV file
+     * Write a row in the CSV file.
      *
      * @param string|array $row The data to add to the CSV
      *
@@ -98,5 +114,4 @@ EOT;
             fclose($this->handle);
         }
     }
-
 }

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,15 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.3.2|<7.0",
         "avro/case-bundle": "*"
     },
     "require-dev": {
         "twig/twig": "*",
-        "doctrine/doctrine-bundle": "*"
+        "doctrine/doctrine-bundle": "*",
+        "doctrine/orm": "*",
+        "phpunit/phpunit": "~4.0",
+        "symfony/form": "<3.0"
     },
     "autoload": {
         "psr-0": { "Avro\\CsvBundle": "" }


### PR DESCRIPTION
Fixes the previous defunct ExportedEvent class to match it's intended usage.

Adds
- `doctrine/orm` and `symfony/form` as require-dev to have all possible dependencies available for further development.
- a config file for `php-cs-fixer`

The code style was fixed according to match current Symfony guidelines. This includes removing unused use and also fixes some missing / wrong PHPDoc type hints. Also added the copyright info to some more files.

Also added `ImportFormType::configureOptions` for Symfony 3.0 compatibility. `ImportFormType::setDefaultOptions` is now a BC layer for 2.x users.
