### PR TITLE
composer '*' to 'dev-master'

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This bundle is listed on packagist.
 Simply add it to your apps composer.json file
 
 ``` js
-    "avro/csv-bundle": "*"
+    "avro/csv-bundle": "dev-master"
 ```
 
 Enable the bundle in the kernel as well as the dependent AvroCaseBundle:


### PR DESCRIPTION
there is an error when you install with "*" but "dev-master" works
